### PR TITLE
Flow expose send control with pubsub messages

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1929,7 +1929,17 @@ func (gs *GossipSubRouter) WithDefaultTagTracer() Option {
 
 // SendControl dispatches the given set of control messages to the given peer.
 func (gs *GossipSubRouter) SendControl(p peer.ID, ctl *pb.ControlMessage) bool {
-	out := rpcWithControl(nil, ctl.Ihave, ctl.Iwant, ctl.Graft, ctl.Prune)
+	return gs.sendControl(nil, p, ctl)
+}
+
+// SendControlWithMessages dispatches the given set of pubsub and control messages to the given peer.
+func (gs *GossipSubRouter) SendControlWithMessages(msgs []*pb.Message, p peer.ID, ctl *pb.ControlMessage) bool {
+	return gs.sendControl(msgs, p, ctl)
+}
+
+// sendControl dispatches the given set of control messages to the given peer.
+func (gs *GossipSubRouter) sendControl(msgs []*pb.Message, p peer.ID, ctl *pb.ControlMessage) bool {
+	out := rpcWithControl(msgs, ctl.Ihave, ctl.Iwant, ctl.Graft, ctl.Prune)
 	return gs.sendRPC(p, out)
 }
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1928,17 +1928,7 @@ func (gs *GossipSubRouter) WithDefaultTagTracer() Option {
 }
 
 // SendControl dispatches the given set of control messages to the given peer.
-func (gs *GossipSubRouter) SendControl(p peer.ID, ctl *pb.ControlMessage) bool {
-	return gs.sendControl(nil, p, ctl)
-}
-
-// SendControlWithMessages dispatches the given set of pubsub and control messages to the given peer.
-func (gs *GossipSubRouter) SendControlWithMessages(msgs []*pb.Message, p peer.ID, ctl *pb.ControlMessage) bool {
-	return gs.sendControl(msgs, p, ctl)
-}
-
-// sendControl dispatches the given set of control messages to the given peer.
-func (gs *GossipSubRouter) sendControl(msgs []*pb.Message, p peer.ID, ctl *pb.ControlMessage) bool {
+func (gs *GossipSubRouter) SendControl(p peer.ID, ctl *pb.ControlMessage, msgs ...*pb.Message) bool {
 	out := rpcWithControl(msgs, ctl.Ihave, ctl.Iwant, ctl.Graft, ctl.Prune)
 	return gs.sendRPC(p, out)
 }


### PR DESCRIPTION
This PR adds []*pb.Message argument to the SendControl gossip router func used in our insecure tests. 